### PR TITLE
Update AXS token logo on Bsctestnet

### DIFF
--- a/tokens/bsc-testnet.json
+++ b/tokens/bsc-testnet.json
@@ -37,6 +37,6 @@
     "address": "0x6b9A9df1e6a29F17BFC79040A8f505Aaa8866b6e",
     "chainId": 97,
     "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/binance/assets/USDT-6D8/logo.png"
+    "logoURI": "https://www.bscscan.com/token/images/axieinfinity_32.png"
   }
 ]


### PR DESCRIPTION
#### What does this PR do?
- This PR changes the AXS token logo on BSC testnet to the real AXS logo because the current logo is USDT logo link.